### PR TITLE
Add `.vscodeignore` and remove `files` property from `package.json`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,13 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+test/**
+src/**
+**/*.map
+*.vsix
+.gitignore
+tsconfig.json
+vsc-extension-quickstart.md
+tslint.json
+tsup.config.ts
+dist

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "vscode": "^1.77.0"
   },
-  "files": [
-    "/dist/cli"
-  ],
   "activationEvents": [],
   "contributors": [
     "Seismic core team"


### PR DESCRIPTION
This PR adds`.vscodeignore` and remove the `files` property from `package.json` for `vsce package` to successfully build a `.vsix` file.