### PR TITLE
`v0.0.179`

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,37 +87,37 @@
       "type": "object",
       "title": "Seismic configuration",
       "properties": {
-        "solidity.nodemodulespackage": {
+        "seismic.solidity.nodemodulespackage": {
           "type": "string",
           "default": "solc",
           "description": "The node modules package to find the solcjs compiler"
         },
-        "solidity.compileUsingRemoteVersion": {
+        "seismic.solidity.compileUsingRemoteVersion": {
           "type": "string",
           "default": "latest",
           "description": "Configuration to download a 'remote' solc (js) version binary file from 'https://seismicsystems.github.io/solc-bin', for example: 'latest' will always use the latest version, or a specific version like: 'v0.4.3+commit.2353da71', use the command 'Solidity: Get solidity releases' to list all versions available, or just right click in a solidity file and select either `Solidity: Change global compiler version (Remote)` or `Solidity: Change workspace compiler version (Remote)` to use the wizard to set the correct version or setting for either the current workspace or globally"
         },
-        "seismic.compilerOptimization": {
+        "seismic.solidity.compilerOptimization": {
           "type": "number",
           "default": 200,
           "description": "Optimize for how many times you intend to run the code. Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
         },
-        "solidity.evmVersion": {
+        "seismic-solidity.evmVersion": {
           "type": "string",
           "default": "",
           "description": "Evm version, ie london, istanbul, petersburg, constantinople, byzantium, tangerineWhistle, spuriousDragon, homestead, frontier, or leave it blank for the default evm version"
         },
-        "solidity.viaIR": {
+        "seismic.solidity.viaIR": {
           "type": "boolean",
           "default": false,
           "description": "Compile using the intermediate representation (IR) instead of the AST"
         },
-        "solidity.compileUsingLocalVersion": {
+        "seismic.solidity.compileUsingLocalVersion": {
           "type": "string",
           "default": "",
           "description": "Compile using a local solc (js) binary file, please include the path of the file if wanted: 'C://v0.4.3+commit.2353da71.js'"
         },
-        "solidity.defaultCompiler": {
+        "seismic.solidity.defaultCompiler": {
           "type": "string",
           "description": "Sets the default compiler and compiler configuration to use. Remote will use the configured compiler using the setting 'compileUsingRemoteVersion' downloaded from https://seismicsystems.github.io/solc-bin', `localFile` will use the solc file in the location configured in the setting: `compileUsingLocalVersion`, `localNodeModule` will attempt to find the solc file in the node_modules folder / package configured on 'nodemodulespackage' and 'embedded' which will use the solc version packaged with the extension. The default is 'remote' which is configured as 'latest'",
           "enum": [
@@ -128,7 +128,7 @@
           ],
           "default": "remote"
         },
-        "solidity.linter": {
+        "seismic.solidity.linter": {
           "type": "string",
           "enum": [
             "",
@@ -138,14 +138,14 @@
           "default": "solhint",
           "description": "Enables linting using either solium (ethlint) or solhint. Possible options 'solhint' and 'solium', the default is solhint"
         },
-        "solidity.solhintRules": {
+        "seismic.solidity.solhintRules": {
           "type": [
             "object"
           ],
           "default": null,
           "description": "Solhint linting validation rules"
         },
-        "solidity.formatter": {
+        "seismic.solidity.formatter": {
           "type": "string",
           "default": "prettier",
           "enum": [
@@ -155,7 +155,7 @@
           ],
           "description": "Enables / disables the solidity formatter prettier (default) or forge (note it needs to be installed)"
         },
-        "solidity.soliumRules": {
+        "seismic.solidity.soliumRules": {
           "type": [
             "object"
           ],
@@ -173,17 +173,17 @@
           },
           "description": "Solium linting validation rules"
         },
-        "solidity.enabledAsYouTypeCompilationErrorCheck": {
+        "seismic.solidity.enabledAsYouTypeCompilationErrorCheck": {
           "type": "boolean",
           "default": true,
           "description": "Enables as you type compilation of the document and error highlighting"
         },
-        "solidity.validationDelay": {
+        "seismic.solidity.validationDelay": {
           "type": "number",
           "default": 1500,
           "description": "Delay to trigger the validation of the changes of the current document (compilation, solium)"
         },
-        "solidity.packageDefaultDependenciesDirectory": {
+        "seismic.solidity.packageDefaultDependenciesDirectory": {
           "type": [
             "string",
             "string[]"
@@ -194,12 +194,12 @@
           ],
           "description": "Default directory for Packages Dependencies, i.e: 'node_modules', 'lib'. This is used to avoid typing imports with that path prefix, multiple dependency paths can be set as an array: ['node_modules', 'lib'] "
         },
-        "solidity.monoRepoSupport": {
+        "seismic.solidity.monoRepoSupport": {
           "type": "boolean",
           "default": true,
           "description": "Enables mono repo support in the current workspace, a project folder will be signaled if a file is found on the current folder or above including: remappings.txt, truffle-config.js, brownie-config.yaml, foundry.toml, hardhat.config.js, hardhat.config.ts, dappfile"
         },
-        "solidity.packageDefaultDependenciesContractsDirectory": {
+        "seismic.solidity.packageDefaultDependenciesContractsDirectory": {
           "type": [
             "string",
             "string[]"
@@ -211,37 +211,37 @@
           ],
           "description": "Default directory where the Package Dependency store its contracts, i.e: 'src', 'contracts', or just a blank string '', this is used to avoid typing imports with subfolder paths"
         },
-        "solidity.remappings": {
+        "seismic.solidity.remappings": {
           "type": "array",
           "default": [],
           "description": "Remappings to resolve contracts to local files / directories, i.e: [\"@openzeppelin/=lib/openzeppelin-contracts\",\"ds-test/=lib/ds-test/src/\"]"
         },
-        "solidity.remappingsWindows": {
+        "seismic.solidity.remappingsWindows": {
           "type": "array",
           "default": [],
           "description": "Windows Remappings to resolve contracts to local Windows files / directories (Note this overrides the generic remapping settings if the OS is Windows) , i.e: [\"@openzeppelin/=C:/lib/openzeppelin-contracts\",\"ds-test/=C:/lib/ds-test/src/\"]"
         },
-        "solidity.remappingsUnix": {
+        "seismic.solidity.remappingsUnix": {
           "type": "array",
           "default": [],
           "description": "Unix Remappings to resolve contracts to local Unix files / directories (Note this overrides the generic remapping settings if the OS is Unix based), i.e: [\"@openzeppelin/=/opt/lib/openzeppelin-contracts\",\"ds-test/=/opt/lib/ds-test/src/\"]"
         },
-        "solidity.explorer_etherscan_apikey": {
+        "seismic.solidity.explorer_etherscan_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading ethereum smart contracts from etherscan.io"
         },
-        "solidity.explorer_etherscan_optimism_apikey": {
+        "seismic.solidity.explorer_etherscan_optimism_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading optimism smart contracts from api-optimistic.etherscan.io"
         },
-        "solidity.explorer_bscscan_apikey": {
+        "seismic.solidity.explorer_bscscan_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading Binance smart chain smart contracts from api.bscscan.com"
         },
-        "solidity.explorer_polygonscan_apikey": {
+        "seismic.solidity.explorer_polygonscan_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading polygon smart contracts from api.polygonscan.com"

--- a/package.json
+++ b/package.json
@@ -284,115 +284,115 @@
     },
     "commands": [
       {
-        "command": "solidity.compile.active",
+        "command": "seismic.compile.active",
         "title": "Seismic: Compile Contract"
       },
       {
-        "command": "solidity.compile.activeUsingRemote",
+        "command": "seismic.compile.activeUsingRemote",
         "title": "Seismic: Compile with configured Remote version"
       },
       {
-        "command": "solidity.compile.activeUsingLocalFile",
+        "command": "seismic.compile.activeUsingLocalFile",
         "title": "Seismic: Compile with configured Local solc file"
       },
       {
-        "command": "solidity.compile.activeUsingNodeModule",
+        "command": "seismic.compile.activeUsingNodeModule",
         "title": "Seismic: Compile with configured Node module"
       },
       {
-        "command": "solidity.compile",
+        "command": "seismic.compile", 
         "title": "Seismic: Compile All"
       },
       {
-        "command": "solidity.compilerInfo",
+        "command": "seismic.compilerInfo",
         "title": "Seismic: Compiler Information"
       },
       {
-        "command": "solidity.solcReleases",
+        "command": "seismic.solcReleases",
         "title": "Seismic: Get solidity releases"
       },
       {
-        "command": "solidity.codegenNethereumCodeGenSettings",
+        "command": "seismic.codegenNethereumCodeGenSettings",
         "title": "Seismic: Create 'nethereum-gen.settings' with default values at root"
       },
       {
-        "command": "solidity.codegenCSharpProject",
+        "command": "seismic.codegenCSharpProject",
         "title": "Seismic: Code generate CSharp contract definition"
       },
       {
-        "command": "solidity.compileAndCodegenCSharpProject",
+        "command": "seismic.compileAndCodegenCSharpProject",
         "title": "Seismic: Compile and Code generate CSharp contract definition"
       },
       {
-        "command": "solidity.codegenVbNetProject",
+        "command": "seismic.codegenVbNetProject",
         "title": "Seismic: Code generate VB.Net contract definition"
       },
       {
-        "command": "solidity.compileAndCodegenVbNetProject",
+        "command": "seismic.compileAndCodegenVbNetProject",
         "title": "Seismic: Compile and Code generate VB.Net contract definition"
       },
       {
-        "command": "solidity.codegenFSharpProject",
+        "command": "seismic.codegenFSharpProject",
         "title": "Seismic: Code generate FSharp contract definition"
       },
       {
-        "command": "solidity.compileAndCodegenFSharpProject",
+        "command": "seismic.compileAndCodegenFSharpProject",
         "title": "Seismic: Compile and Code generate FSharp contract definition"
       },
       {
-        "command": "solidity.codegenCSharpProjectAll",
+        "command": "seismic.codegenCSharpProjectAll",
         "title": "Seismic: Code generate CSharp Project from all compiled files"
       },
       {
-        "command": "solidity.codegenVbNetProjectAll",
+        "command": "seismic.codegenVbNetProjectAll",
         "title": "Seismic: Code generate VB.Net Project from all compiled files"
       },
       {
-        "command": "solidity.codegenFSharpProjectAll",
+        "command": "seismic.codegenFSharpProjectAll",
         "title": "Seismic: Code generate FSharp Project from all compiled files"
       },
       {
-        "command": "solidity.codegenCSharpProjectAllAbiCurrent",
+        "command": "seismic.codegenCSharpProjectAllAbiCurrent",
         "title": "Seismic: Code generate CSharp Definitions for Abi files in current folder"
       },
       {
-        "command": "solidity.codegenVbNetProjectAllAbiCurrent",
+        "command": "seismic.codegenVbNetProjectAllAbiCurrent",
         "title": "Seismic: Code generate VB.Net Definitions for Abi files in current folder"
       },
       {
-        "command": "solidity.codegenFSharpProjectAllAbiCurrent",
+        "command": "seismic.codegenFSharpProjectAllAbiCurrent",
         "title": "Seismic: Code generate FSharp Definitions for Abi files in current folder"
       },
       {
-        "command": "solidity.codeGenFromNethereumGenAbisFile",
+        "command": "seismic.codeGenFromNethereumGenAbisFile",
         "title": "Seismic: Code generate Definitions for Abi files in selected 'nethereum-gen.multisettings'"
       },
       {
-        "command": "solidity.fixDocument",
+        "command": "seismic.fixDocument",
         "title": "Seismic: Fix document rules using Solium"
       },
       {
-        "command": "solidity.selectWorkspaceRemoteSolcVersion",
+        "command": "seismic.selectWorkspaceRemoteSolcVersion",
         "title": "Seismic: Change workspace compiler version (Remote)"
       },
       {
-        "command": "solidity.selectGlobalRemoteSolcVersion",
+        "command": "seismic.selectGlobalRemoteSolcVersion",
         "title": "Seismic: Change global compiler version (Remote)"
       },
       {
-        "command": "solidity.downloadRemoteSolcVersion",
+        "command": "seismic.downloadRemoteSolcVersion",
         "title": "Seismic: Download compiler"
       },
       {
-        "command": "solidity.downloadRemoteVersionAndSetLocalPathSetting",
+        "command": "seismic.downloadRemoteVersionAndSetLocalPathSetting",
         "title": "Seismic: Download compiler and set workspace local Path"
       },
       {
-        "command": "solidity.changeDefaultCompilerType",
+        "command": "seismic.changeDefaultCompilerType",
         "title": "Seismic: Change the default workspace compiler to Remote, Local, NodeModule, Embedded"
       },
       {
-        "command": "solidity.downloadVerifiedSmartContractEtherscan",
+        "command": "seismic.downloadVerifiedSmartContractEtherscan",
         "title": "Seismic: Download smart contract source code / abi (Etherscan)"
       }
     ],
@@ -400,213 +400,213 @@
       "commandPalette": [
         {
           "when": "resourceExtname == .abi || resourceExtname == .json",
-          "command": "solidity.codegenCSharpProject"
+          "command": "seismic.codegenCSharpProject"
         },
         {
           "when": "resourceExtname == .abi || resourceExtname == .json",
-          "command": "solidity.codegenVbNetProject"
+          "command": "seismic.codegenVbNetProject"
         },
         {
           "when": "resourceExtname == .abi || resourceExtname == .json",
-          "command": "solidity.codegenFSharpProject"
+          "command": "seismic.codegenFSharpProject"
         },
         {
           "when": "resourceExtname == .sol",
-          "command": "solidity.compile.active"
+          "command": "seismic.compile.active"
         },
         {
           "when": "explorerResourceIsFolder || resourceExtname == .sol || resourceExtname == .abi",
-          "command": "solidity.downloadVerifiedSmartContractEtherscan"
+          "command": "seismic.downloadVerifiedSmartContractEtherscan"
         },
         {
           "when": "resourceExtname == .sol",
-          "command": "solidity.compile"
+          "command": "seismic.compile"
         }
       ],
       "editor/context": [
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compile.active",
+          "command": "seismic.compile.active",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compile",
+          "command": "seismic.compile",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compilerInfo",
+          "command": "seismic.compilerInfo",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compile.activeUsingRemote",
+          "command": "seismic.compile.activeUsingRemote",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compile.activeUsingLocalFile",
+          "command": "seismic.compile.activeUsingLocalFile",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compile.activeUsingNodeModule",
+          "command": "seismic.compile.activeUsingNodeModule",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.downloadVerifiedSmartContractEtherscan",
+          "command": "seismic.downloadVerifiedSmartContractEtherscan",
           "group": "1_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.changeDefaultCompilerType",
+          "command": "seismic.changeDefaultCompilerType",
           "group": "2_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.solcReleases",
+          "command": "seismic.solcReleases",
           "group": "2_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.selectGlobalRemoteSolcVersion",
+          "command": "seismic.selectGlobalRemoteSolcVersion",
           "group": "2_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.selectWorkspaceRemoteSolcVersion",
+          "command": "seismic.selectWorkspaceRemoteSolcVersion",
           "group": "2_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.downloadRemoteSolcVersion",
+          "command": "seismic.downloadRemoteSolcVersion",
           "group": "2_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.downloadRemoteVersionAndSetLocalPathSetting",
+          "command": "seismic.downloadRemoteVersionAndSetLocalPathSetting",
           "group": "2_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.codegenNethereumCodeGenSettings",
+          "command": "seismic.codegenNethereumCodeGenSettings",
           "group": "3_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compileAndCodegenCSharpProject",
+          "command": "seismic.compileAndCodegenCSharpProject",
           "group": "3_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compileAndCodegenVbNetProject",
+          "command": "seismic.compileAndCodegenVbNetProject",
           "group": "3_solidity"
         },
         {
           "when": "editorLangId == 'solidity'",
-          "command": "solidity.compileAndCodegenFSharpProject",
+          "command": "seismic.compileAndCodegenFSharpProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenCSharpProject",
+          "command": "seismic.codegenCSharpProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenVbNetProject",
+          "command": "seismic.codegenVbNetProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenFSharpProject",
+          "command": "seismic.codegenFSharpProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenCSharpProjectAllAbiCurrent",
+          "command": "seismic.codegenCSharpProjectAllAbiCurrent",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenVbNetProjectAllAbiCurrent",
+          "command": "seismic.codegenVbNetProjectAllAbiCurrent",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenFSharpProjectAllAbiCurrent",
+          "command": "seismic.codegenFSharpProjectAllAbiCurrent",
           "group": "3_solidity"
         },
         {
           "when": "resourceFilename =~ /^(.*\\.)?nethereum-gen\\.multisettings$/",
-          "command": "solidity.codeGenFromNethereumGenAbisFile",
+          "command": "seismic.codeGenFromNethereumGenAbisFile",
           "group": "3_solidity"
         }
       ],
       "explorer/context": [
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenCSharpProject",
+          "command": "seismic.codegenCSharpProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenVbNetProject",
+          "command": "seismic.codegenVbNetProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenFSharpProject",
+          "command": "seismic.codegenFSharpProject",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .sol",
-          "command": "solidity.compile.active",
+          "command": "seismic.compile.active",
           "group": "2_solidity"
         },
         {
           "when": "resourceExtname == .sol",
-          "command": "solidity.compile",
+          "command": "seismic.compile",
           "group": "2_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenCSharpProjectAllAbiCurrent",
+          "command": "seismic.codegenCSharpProjectAllAbiCurrent",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenVbNetProjectAllAbiCurrent",
+          "command": "seismic.codegenVbNetProjectAllAbiCurrent",
           "group": "3_solidity"
         },
         {
           "when": "resourceExtname == .abi",
-          "command": "solidity.codegenFSharpProjectAllAbiCurrent",
+          "command": "seismic.codegenFSharpProjectAllAbiCurrent",
           "group": "3_solidity"
         },
         {
           "when": "explorerResourceIsFolder || resourceExtname == .sol || resourceExtname == .abi",
-          "command": "solidity.downloadVerifiedSmartContractEtherscan",
+          "command": "seismic.downloadVerifiedSmartContractEtherscan",
           "group": "2_solidity"
         },
         {
           "when": "resourceFilename =~ /^(.*\\.)?nethereum-gen\\.multisettings$/",
-          "command": "solidity.codeGenFromNethereumGenAbisFile",
+          "command": "seismic.codeGenFromNethereumGenAbisFile",
           "group": "3_solidity"
         }
       ]
     },
     "keybindings": [
       {
-        "command": "solidity.compile.active",
+        "command": "seismic.compile.active",
         "key": "f5",
         "mac": "f5",
         "when": "editorTextFocus && editorLangId == 'solidity'"
       },
       {
-        "command": "solidity.compile",
+        "command": "seismic.compile",
         "key": "Ctrl+f5",
         "mac": "Cmd+f5",
         "when": "editorTextFocus && editorLangId == 'solidity'"

--- a/package.json
+++ b/package.json
@@ -87,37 +87,37 @@
       "type": "object",
       "title": "Seismic configuration",
       "properties": {
-        "seismic.solidity.nodemodulespackage": {
+        "seismic.nodemodulespackage": {
           "type": "string",
           "default": "solc",
           "description": "The node modules package to find the solcjs compiler"
         },
-        "seismic.solidity.compileUsingRemoteVersion": {
+        "seismic.compileUsingRemoteVersion": {
           "type": "string",
           "default": "latest",
           "description": "Configuration to download a 'remote' solc (js) version binary file from 'https://seismicsystems.github.io/solc-bin', for example: 'latest' will always use the latest version, or a specific version like: 'v0.4.3+commit.2353da71', use the command 'Solidity: Get solidity releases' to list all versions available, or just right click in a solidity file and select either `Solidity: Change global compiler version (Remote)` or `Solidity: Change workspace compiler version (Remote)` to use the wizard to set the correct version or setting for either the current workspace or globally"
         },
-        "seismic.solidity.compilerOptimization": {
+        "seismic.compilerOptimization": {
           "type": "number",
           "default": 200,
           "description": "Optimize for how many times you intend to run the code. Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
         },
-        "seismic.solidity.evmVersion": {
+        "seismic.evmVersion": {
           "type": "string",
           "default": "",
           "description": "Evm version, ie london, istanbul, petersburg, constantinople, byzantium, tangerineWhistle, spuriousDragon, homestead, frontier, or leave it blank for the default evm version"
         },
-        "seismic.solidity.viaIR": {
+        "seismic.viaIR": {
           "type": "boolean",
           "default": false,
           "description": "Compile using the intermediate representation (IR) instead of the AST"
         },
-        "seismic.solidity.compileUsingLocalVersion": {
+        "seismic.compileUsingLocalVersion": {
           "type": "string",
           "default": "",
           "description": "Compile using a local solc (js) binary file, please include the path of the file if wanted: 'C://v0.4.3+commit.2353da71.js'"
         },
-        "seismic.solidity.defaultCompiler": {
+        "seismic.defaultCompiler": {
           "type": "string",
           "description": "Sets the default compiler and compiler configuration to use. Remote will use the configured compiler using the setting 'compileUsingRemoteVersion' downloaded from https://seismicsystems.github.io/solc-bin', `localFile` will use the solc file in the location configured in the setting: `compileUsingLocalVersion`, `localNodeModule` will attempt to find the solc file in the node_modules folder / package configured on 'nodemodulespackage' and 'embedded' which will use the solc version packaged with the extension. The default is 'remote' which is configured as 'latest'",
           "enum": [
@@ -128,7 +128,7 @@
           ],
           "default": "remote"
         },
-        "seismic.solidity.linter": {
+        "seismic.linter": {
           "type": "string",
           "enum": [
             "",
@@ -138,14 +138,14 @@
           "default": "solhint",
           "description": "Enables linting using either solium (ethlint) or solhint. Possible options 'solhint' and 'solium', the default is solhint"
         },
-        "seismic.solidity.solhintRules": {
+        "seismic.solhintRules": {
           "type": [
             "object"
           ],
           "default": null,
           "description": "Solhint linting validation rules"
         },
-        "seismic.solidity.formatter": {
+        "seismic.formatter": {
           "type": "string",
           "default": "prettier",
           "enum": [
@@ -155,7 +155,7 @@
           ],
           "description": "Enables / disables the solidity formatter prettier (default) or forge (note it needs to be installed)"
         },
-        "seismic.solidity.soliumRules": {
+        "seismic.soliumRules": {
           "type": [
             "object"
           ],
@@ -173,17 +173,17 @@
           },
           "description": "Solium linting validation rules"
         },
-        "seismic.solidity.enabledAsYouTypeCompilationErrorCheck": {
+        "seismic.enabledAsYouTypeCompilationErrorCheck": {
           "type": "boolean",
           "default": true,
           "description": "Enables as you type compilation of the document and error highlighting"
         },
-        "seismic.solidity.validationDelay": {
+        "seismic.validationDelay": {
           "type": "number",
           "default": 1500,
           "description": "Delay to trigger the validation of the changes of the current document (compilation, solium)"
         },
-        "seismic.solidity.packageDefaultDependenciesDirectory": {
+        "seismic.packageDefaultDependenciesDirectory": {
           "type": [
             "string",
             "string[]"
@@ -194,12 +194,12 @@
           ],
           "description": "Default directory for Packages Dependencies, i.e: 'node_modules', 'lib'. This is used to avoid typing imports with that path prefix, multiple dependency paths can be set as an array: ['node_modules', 'lib'] "
         },
-        "seismic.solidity.monoRepoSupport": {
+        "seismic.monoRepoSupport": {
           "type": "boolean",
           "default": true,
           "description": "Enables mono repo support in the current workspace, a project folder will be signaled if a file is found on the current folder or above including: remappings.txt, truffle-config.js, brownie-config.yaml, foundry.toml, hardhat.config.js, hardhat.config.ts, dappfile"
         },
-        "seismic.solidity.packageDefaultDependenciesContractsDirectory": {
+        "seismic.packageDefaultDependenciesContractsDirectory": {
           "type": [
             "string",
             "string[]"
@@ -211,37 +211,37 @@
           ],
           "description": "Default directory where the Package Dependency store its contracts, i.e: 'src', 'contracts', or just a blank string '', this is used to avoid typing imports with subfolder paths"
         },
-        "seismic.solidity.remappings": {
+        "seismic.remappings": {
           "type": "array",
           "default": [],
           "description": "Remappings to resolve contracts to local files / directories, i.e: [\"@openzeppelin/=lib/openzeppelin-contracts\",\"ds-test/=lib/ds-test/src/\"]"
         },
-        "seismic.solidity.remappingsWindows": {
+        "seismic.remappingsWindows": {
           "type": "array",
           "default": [],
           "description": "Windows Remappings to resolve contracts to local Windows files / directories (Note this overrides the generic remapping settings if the OS is Windows) , i.e: [\"@openzeppelin/=C:/lib/openzeppelin-contracts\",\"ds-test/=C:/lib/ds-test/src/\"]"
         },
-        "seismic.solidity.remappingsUnix": {
+        "seismic.remappingsUnix": {
           "type": "array",
           "default": [],
           "description": "Unix Remappings to resolve contracts to local Unix files / directories (Note this overrides the generic remapping settings if the OS is Unix based), i.e: [\"@openzeppelin/=/opt/lib/openzeppelin-contracts\",\"ds-test/=/opt/lib/ds-test/src/\"]"
         },
-        "seismic.solidity.explorer_etherscan_apikey": {
+        "seismic.explorer_etherscan_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading ethereum smart contracts from etherscan.io"
         },
-        "seismic.solidity.explorer_etherscan_optimism_apikey": {
+        "seismic.explorer_etherscan_optimism_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading optimism smart contracts from api-optimistic.etherscan.io"
         },
-        "seismic.solidity.explorer_bscscan_apikey": {
+        "seismic.explorer_bscscan_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading Binance smart chain smart contracts from api.bscscan.com"
         },
-        "seismic.solidity.explorer_polygonscan_apikey": {
+        "seismic.explorer_polygonscan_apikey": {
           "type": "string",
           "default": "YourApiKey",
           "description": "Api key for downloading polygon smart contracts from api.polygonscan.com"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "seismic",
   "description": "Seismic extension for Visual Studio Code",
   "keywords": [
-      "seismic"
+    "seismic"
   ],
   "version": "0.0.179",
   "publisher": "SeismicSys",
@@ -300,7 +300,7 @@
         "title": "Seismic: Compile with configured Node module"
       },
       {
-        "command": "seismic.compile", 
+        "command": "seismic.compile",
         "title": "Seismic: Compile All"
       },
       {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
           "default": 200,
           "description": "Optimize for how many times you intend to run the code. Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
         },
-        "seismic-solidity.evmVersion": {
+        "seismic.solidity.evmVersion": {
           "type": "string",
           "default": "",
           "description": "Evm version, ie london, istanbul, petersburg, constantinople, byzantium, tangerineWhistle, spuriousDragon, homestead, frontier, or leave it blank for the default evm version"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
       "seismic"
   ],
-  "version": "0.0.178",
+  "version": "0.0.179",
   "publisher": "SeismicSys",
   "license": "MIT",
   "engines": {
@@ -85,7 +85,7 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "Solidity configuration",
+      "title": "Seismic configuration",
       "properties": {
         "solidity.nodemodulespackage": {
           "type": "string",
@@ -97,7 +97,7 @@
           "default": "latest",
           "description": "Configuration to download a 'remote' solc (js) version binary file from 'https://seismicsystems.github.io/solc-bin', for example: 'latest' will always use the latest version, or a specific version like: 'v0.4.3+commit.2353da71', use the command 'Solidity: Get solidity releases' to list all versions available, or just right click in a solidity file and select either `Solidity: Change global compiler version (Remote)` or `Solidity: Change workspace compiler version (Remote)` to use the wizard to set the correct version or setting for either the current workspace or globally"
         },
-        "solidity.compilerOptimization": {
+        "seismic.compilerOptimization": {
           "type": "number",
           "default": 200,
           "description": "Optimize for how many times you intend to run the code. Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
@@ -285,115 +285,115 @@
     "commands": [
       {
         "command": "solidity.compile.active",
-        "title": "Solidity: Compile Contract"
+        "title": "Seismic: Compile Contract"
       },
       {
         "command": "solidity.compile.activeUsingRemote",
-        "title": "Solidity: Compile with configured Remote version"
+        "title": "Seismic: Compile with configured Remote version"
       },
       {
         "command": "solidity.compile.activeUsingLocalFile",
-        "title": "Solidity: Compile with configured Local solc file"
+        "title": "Seismic: Compile with configured Local solc file"
       },
       {
         "command": "solidity.compile.activeUsingNodeModule",
-        "title": "Solidity: Compile with configured Node module"
+        "title": "Seismic: Compile with configured Node module"
       },
       {
         "command": "solidity.compile",
-        "title": "Solidity: Compile All"
+        "title": "Seismic: Compile All"
       },
       {
         "command": "solidity.compilerInfo",
-        "title": "Solidity: Compiler Information"
+        "title": "Seismic: Compiler Information"
       },
       {
         "command": "solidity.solcReleases",
-        "title": "Solidity: Get solidity releases"
+        "title": "Seismic: Get solidity releases"
       },
       {
         "command": "solidity.codegenNethereumCodeGenSettings",
-        "title": "Solidity: Create 'nethereum-gen.settings' with default values at root"
+        "title": "Seismic: Create 'nethereum-gen.settings' with default values at root"
       },
       {
         "command": "solidity.codegenCSharpProject",
-        "title": "Solidity: Code generate CSharp contract definition"
+        "title": "Seismic: Code generate CSharp contract definition"
       },
       {
         "command": "solidity.compileAndCodegenCSharpProject",
-        "title": "Solidity: Compile and Code generate CSharp contract definition"
+        "title": "Seismic: Compile and Code generate CSharp contract definition"
       },
       {
         "command": "solidity.codegenVbNetProject",
-        "title": "Solidity: Code generate VB.Net contract definition"
+        "title": "Seismic: Code generate VB.Net contract definition"
       },
       {
         "command": "solidity.compileAndCodegenVbNetProject",
-        "title": "Solidity: Compile and Code generate VB.Net contract definition"
+        "title": "Seismic: Compile and Code generate VB.Net contract definition"
       },
       {
         "command": "solidity.codegenFSharpProject",
-        "title": "Solidity: Code generate FSharp contract definition"
+        "title": "Seismic: Code generate FSharp contract definition"
       },
       {
         "command": "solidity.compileAndCodegenFSharpProject",
-        "title": "Solidity: Compile and Code generate FSharp contract definition"
+        "title": "Seismic: Compile and Code generate FSharp contract definition"
       },
       {
         "command": "solidity.codegenCSharpProjectAll",
-        "title": "Solidity: Code generate CSharp Project from all compiled files"
+        "title": "Seismic: Code generate CSharp Project from all compiled files"
       },
       {
         "command": "solidity.codegenVbNetProjectAll",
-        "title": "Solidity: Code generate VB.Net Project from all compiled files"
+        "title": "Seismic: Code generate VB.Net Project from all compiled files"
       },
       {
         "command": "solidity.codegenFSharpProjectAll",
-        "title": "Solidity: Code generate FSharp Project from all compiled files"
+        "title": "Seismic: Code generate FSharp Project from all compiled files"
       },
       {
         "command": "solidity.codegenCSharpProjectAllAbiCurrent",
-        "title": "Solidity: Code generate CSharp Definitions for Abi files in current folder"
+        "title": "Seismic: Code generate CSharp Definitions for Abi files in current folder"
       },
       {
         "command": "solidity.codegenVbNetProjectAllAbiCurrent",
-        "title": "Solidity: Code generate VB.Net Definitions for Abi files in current folder"
+        "title": "Seismic: Code generate VB.Net Definitions for Abi files in current folder"
       },
       {
         "command": "solidity.codegenFSharpProjectAllAbiCurrent",
-        "title": "Solidity: Code generate FSharp Definitions for Abi files in current folder"
+        "title": "Seismic: Code generate FSharp Definitions for Abi files in current folder"
       },
       {
         "command": "solidity.codeGenFromNethereumGenAbisFile",
-        "title": "Solidity: Code generate Definitions for Abi files in selected 'nethereum-gen.multisettings'"
+        "title": "Seismic: Code generate Definitions for Abi files in selected 'nethereum-gen.multisettings'"
       },
       {
         "command": "solidity.fixDocument",
-        "title": "Solidity: Fix document rules using Solium"
+        "title": "Seismic: Fix document rules using Solium"
       },
       {
         "command": "solidity.selectWorkspaceRemoteSolcVersion",
-        "title": "Solidity: Change workspace compiler version (Remote)"
+        "title": "Seismic: Change workspace compiler version (Remote)"
       },
       {
         "command": "solidity.selectGlobalRemoteSolcVersion",
-        "title": "Solidity: Change global compiler version (Remote)"
+        "title": "Seismic: Change global compiler version (Remote)"
       },
       {
         "command": "solidity.downloadRemoteSolcVersion",
-        "title": "Solidity: Download compiler"
+        "title": "Seismic: Download compiler"
       },
       {
         "command": "solidity.downloadRemoteVersionAndSetLocalPathSetting",
-        "title": "Solidity: Download compiler and set workspace local Path"
+        "title": "Seismic: Download compiler and set workspace local Path"
       },
       {
         "command": "solidity.changeDefaultCompilerType",
-        "title": "Solidity: Change the default workspace compiler to Remote, Local, NodeModule, Embedded"
+        "title": "Seismic: Change the default workspace compiler to Remote, Local, NodeModule, Embedded"
       },
       {
         "command": "solidity.downloadVerifiedSmartContractEtherscan",
-        "title": "Solidity: Download smart contract source code / abi (Etherscan)"
+        "title": "Seismic: Download smart contract source code / abi (Etherscan)"
       }
     ],
     "menus": {

--- a/src/client/codeActionProviders/addressChecksumActionProvider.ts
+++ b/src/client/codeActionProviders/addressChecksumActionProvider.ts
@@ -56,7 +56,7 @@ export class AddressChecksumCodeActionProvider implements vscode.CodeActionProvi
         public static createFix(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.CodeAction {
 
             const fix = new vscode.CodeAction(`Change workspace compiler version`, vscode.CodeActionKind.QuickFix);
-            fix.command = { command: 'solidity.selectWorkspaceRemoteSolcVersion',
+            fix.command = { command: 'seismic.selectWorkspaceRemoteSolcVersion',
                             title: 'Change the workspace remote compiler version',
                             tooltip: 'This will open a prompt with the solidity version' };
             fix.diagnostics = [diagnostic];

--- a/src/client/codeActionProviders/addressChecksumActionProvider.ts
+++ b/src/client/codeActionProviders/addressChecksumActionProvider.ts
@@ -43,7 +43,6 @@ export class AddressChecksumCodeActionProvider implements vscode.CodeActionProvi
 
     }
 
-
     export class ChangeCompilerVersionActionProvider implements vscode.CodeActionProvider {
 
 

--- a/src/client/compiler.ts
+++ b/src/client/compiler.ts
@@ -31,7 +31,7 @@ export class Compiler {
             // tslint:disable-next-line:max-line-length
             const compilers: string[] = [compilerType[compilerType.remote], compilerType[compilerType.localFile], compilerType[compilerType.localNodeModule], compilerType[compilerType.embedded]];
             const selectedCompiler: string = await vscode.window.showQuickPick(compilers);
-            vscode.workspace.getConfiguration('solidity').update('defaultCompiler', selectedCompiler, target);
+            vscode.workspace.getConfiguration('seismic').update('defaultCompiler', selectedCompiler, target);
             vscode.window.showInformationMessage('Compiler changed to: ' + selectedCompiler);
         } catch (e) {
             vscode.window.showErrorMessage('Error changing default compiler: ' + e);
@@ -40,7 +40,7 @@ export class Compiler {
 
     public async downloadRemoteVersionAndSetLocalPathSetting(target: vscode.ConfigurationTarget, folderPath: string) {
         const downloadPath = await this.downloadRemoteVersion(folderPath);
-        vscode.workspace.getConfiguration('solidity').update('compileUsingLocalVersion', downloadPath, target);
+        vscode.workspace.getConfiguration('seismic').update('compileUsingLocalVersion', downloadPath, target);
     }
 
     public async downloadRemoteVersion(folderPath: string): Promise<string> {
@@ -89,7 +89,7 @@ export class Compiler {
                     }
                 }
             }
-            vscode.workspace.getConfiguration('solidity').update('compileUsingRemoteVersion', updateValue, target);
+            vscode.workspace.getConfiguration('seismic').update('compileUsingRemoteVersion', updateValue, target);
         });
     }
 
@@ -179,10 +179,10 @@ export class Compiler {
         this.outputChannel.appendLine(this.solcCachePath);
         this.outputChannel.clear();
         this.outputChannel.show();
-        const remoteCompiler = vscode.workspace.getConfiguration('solidity').get<string>('compileUsingRemoteVersion');
-        const localCompiler = vscode.workspace.getConfiguration('solidity').get<string>('compileUsingLocalVersion');
-        const nodeModulePackage = vscode.workspace.getConfiguration('solidity').get<string>('nodemodulespackage');
-        const compilerSetting = vscode.workspace.getConfiguration('solidity').get<string>('defaultCompiler');
+        const remoteCompiler = vscode.workspace.getConfiguration('seismic').get<string>('compileUsingRemoteVersion');
+        const localCompiler = vscode.workspace.getConfiguration('seismic').get<string>('compileUsingLocalVersion');
+        const nodeModulePackage = vscode.workspace.getConfiguration('seismic').get<string>('nodemodulespackage');
+        const compilerSetting = vscode.workspace.getConfiguration('seismic').get<string>('defaultCompiler');
         const defaultCompiler = compilerType[compilerSetting];
         this.outputChannel.appendLine('Initialising compiler with settings:');
         this.outputChannel.appendLine('Remote compiler: ' + remoteCompiler);

--- a/src/client/formatter/formatter.ts
+++ b/src/client/formatter/formatter.ts
@@ -3,7 +3,7 @@ import * as prettier from './prettierFormatter';
 import * as forge from './forgeFormatter';
 
 export async function formatDocument(document: vscode.TextDocument, context: vscode.ExtensionContext): Promise<vscode.TextEdit[]> {
-  const formatter = vscode.workspace.getConfiguration('solidity').get<string>('formatter');
+  const formatter = vscode.workspace.getConfiguration('seismic').get<string>('formatter');
   console.log(formatter);
   switch (formatter) {
     case 'prettier':

--- a/src/client/settingsService.ts
+++ b/src/client/settingsService.ts
@@ -6,50 +6,50 @@ import { EtherscanDomainChainMapper } from '../common/sourceCodeDownloader/ether
 export class SettingsService {
 
     public static getPackageDefaultDependenciesDirectories(): string[] {
-        const packageDefaultDependenciesDirectory = vscode.workspace.getConfiguration('solidity').get<string|string[]>('packageDefaultDependenciesDirectory');
+        const packageDefaultDependenciesDirectory = vscode.workspace.getConfiguration('seismic').get<string|string[]>('packageDefaultDependenciesDirectory');
         if (typeof packageDefaultDependenciesDirectory === 'string') {return [<string>packageDefaultDependenciesDirectory]; }
         return <string[]>packageDefaultDependenciesDirectory;
     }
 
     public static getPackageDefaultDependenciesContractsDirectory(): string[] {
-        const packageDefaultDependenciesContractsDirectory = vscode.workspace.getConfiguration('solidity').get<string|string[]>('packageDefaultDependenciesContractsDirectory');
+        const packageDefaultDependenciesContractsDirectory = vscode.workspace.getConfiguration('seismic').get<string|string[]>('packageDefaultDependenciesContractsDirectory');
         if (typeof packageDefaultDependenciesContractsDirectory === 'string') {return [<string>packageDefaultDependenciesContractsDirectory]; }
         return <string[]>packageDefaultDependenciesContractsDirectory;
     }
 
     public static getCompilerOptimisation(): number {
-        return vscode.workspace.getConfiguration('solidity').get<number>('compilerOptimization');
+        return vscode.workspace.getConfiguration('seismic').get<number>('compilerOptimization');
     }
 
     public static getEVMVersion(): string {
-        return vscode.workspace.getConfiguration('solidity').get<string>('evmVersion');
+        return vscode.workspace.getConfiguration('seismic').get<string>('evmVersion');
     }
 
     public static getViaIR(): boolean {
-        return vscode.workspace.getConfiguration('solidity').get<boolean>('viaIR');
+        return vscode.workspace.getConfiguration('seismic').get<boolean>('viaIR');
     }
 
 
     public static getRemappings(): string[] {
-        return vscode.workspace.getConfiguration('solidity').get<string[]>('remappings');
+        return vscode.workspace.getConfiguration('seismic').get<string[]>('remappings');
     }
 
     public static getRemappingsWindows(): string[] {
-        return vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsWindows');
+        return vscode.workspace.getConfiguration('seismic').get<string[]>('remappingsWindows');
     }
 
     public static getRemappingsUnix(): string[] {
-        return vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsUnix');
+        return vscode.workspace.getConfiguration('seismic').get<string[]>('remappingsUnix');
     }
 
     public static getMonoRepoSupport(): boolean {
-        return vscode.workspace.getConfiguration('solidity').get<boolean>('monoRepoSupport');
+        return vscode.workspace.getConfiguration('seismic').get<boolean>('monoRepoSupport');
     }
 
     public static getExplorerEtherscanBasedApiKey(server: string): string {
 
         const key = EtherscanDomainChainMapper.getApiKeyMappings()[server];
-        return vscode.workspace.getConfiguration('solidity').get<string>(key);
+        return vscode.workspace.getConfiguration('seismic').get<string>(key);
     }
 
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -220,7 +220,7 @@ export async function activate(context: vscode.ExtensionContext) {
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         synchronize: {
             // Synchronize the setting section 'solidity' to the server
-            configurationSection: 'solidity',
+            configurationSection: 'seismic',
             // Notify the server about file changes to '.sol.js files contain in the workspace (TODO node, linter)
             fileEvents: vscode.workspace.createFileSystemWatcher('{**/remappings.txt,**/.solhint.json,**/.soliumrc.json,**/brownie-config.yaml}'),
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ let compiler: Compiler;
 
 export async function activate(context: vscode.ExtensionContext) {
     const ws = workspace.workspaceFolders;
-    diagnosticCollection = vscode.languages.createDiagnosticCollection('solidity');
+    diagnosticCollection = vscode.languages.createDiagnosticCollection('seismic');
     compiler = new Compiler(context.extensionPath);
 
     context.subscriptions.push(diagnosticCollection);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,136 +37,136 @@ export async function activate(context: vscode.ExtensionContext) {
 
     initDiagnosticCollection(diagnosticCollection);
     
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compile.active', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compile.active', async () => {
         const compiledResults = await compileActiveContract(compiler);
         autoCodeGenerateAfterCompilation(compiledResults, null, diagnosticCollection);
         return compiledResults;
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compile.activeUsingRemote', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compile.activeUsingRemote', async () => {
         const compiledResults = await compileActiveContract(compiler, compilerType.remote);
         autoCodeGenerateAfterCompilation(compiledResults, null, diagnosticCollection);
         return compiledResults;
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compile.activeUsingLocalFile', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compile.activeUsingLocalFile', async () => {
         const compiledResults = await compileActiveContract(compiler, compilerType.localFile);
         autoCodeGenerateAfterCompilation(compiledResults, null, diagnosticCollection);
         return compiledResults;
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compile.activeUsingNodeModule', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compile.activeUsingNodeModule', async () => {
         const compiledResults = await compileActiveContract(compiler, compilerType.localNodeModule);
         autoCodeGenerateAfterCompilation(compiledResults, null, diagnosticCollection);
         return compiledResults;
     }));
 
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compile', () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compile', () => {
         compileAllContracts(compiler, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenCSharpProject', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenCSharpProject', (args: any[]) => {
         codeGenerateNethereumCQSCsharp(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compileAndCodegenCSharpProject', async (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compileAndCodegenCSharpProject', async (args: any[]) => {
         const compiledResults = await compileActiveContract(compiler);
         compiledResults.forEach(file => {
             codeGenerateCQS(file, 0, args, diagnosticCollection);
         });
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenNethereumCodeGenSettings', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenNethereumCodeGenSettings', (args: any[]) => {
         generateNethereumCodeSettingsFile();
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenVbNetProject', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenVbNetProject', (args: any[]) => {
         codeGenerateNethereumCQSVbNet(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compileAndCodegenVbNetProject', async (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compileAndCodegenVbNetProject', async (args: any[]) => {
         const compiledResults = await compileActiveContract(compiler);
         compiledResults.forEach(file => {
             codeGenerateCQS(file, 1, args, diagnosticCollection);
         });
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenFSharpProject', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenFSharpProject', (args: any[]) => {
         codeGenerateNethereumCQSFSharp(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compileAndCodegenFSharpProject', async (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compileAndCodegenFSharpProject', async (args: any[]) => {
         const compiledResults = await compileActiveContract(compiler);
         compiledResults.forEach(file => {
             codeGenerateCQS(file, 3, args, diagnosticCollection);
         });
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenCSharpProjectAll', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenCSharpProjectAll', (args: any[]) => {
         codeGenerateNethereumCQSCSharpAll(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenVbNetProjectAll', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenVbNetProjectAll', (args: any[]) => {
         codeGenerateNethereumCQSVbAll(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenFSharpProjectAll', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenFSharpProjectAll', (args: any[]) => {
         codeGenerateNethereumCQSFSharpAll(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenCSharpProjectAllAbiCurrent', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenCSharpProjectAllAbiCurrent', (args: any[]) => {
         codeGenerateAllFilesFromAbiInCurrentFolder(0, args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenVbNetProjectAllAbiCurrent', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenVbNetProjectAllAbiCurrent', (args: any[]) => {
         codeGenerateAllFilesFromAbiInCurrentFolder(1, args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codegenFSharpProjectAllAbiCurrent', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codegenFSharpProjectAllAbiCurrent', (args: any[]) => {
         codeGenerateAllFilesFromAbiInCurrentFolder(3, args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.codeGenFromNethereumGenAbisFile', (args: any[]) => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.codeGenFromNethereumGenAbisFile', (args: any[]) => {
         codeGenerateAllFilesFromNethereumGenAbisFile(args, diagnosticCollection);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.fixDocument', () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.fixDocument', () => {
         lintAndfixCurrentDocument();
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.compilerInfo', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.compilerInfo', async () => {
         await compiler.outputCompilerInfoEnsuringInitialised();
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.solcReleases', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.solcReleases', async () => {
         compiler.outputSolcReleases();
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.selectWorkspaceRemoteSolcVersion', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.selectWorkspaceRemoteSolcVersion', async () => {
         compiler.selectRemoteVersion(vscode.ConfigurationTarget.Workspace);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.downloadRemoteSolcVersion', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.downloadRemoteSolcVersion', async () => {
         const root = workspaceUtil.getCurrentWorkspaceRootFolder();
         compiler.downloadRemoteVersion(root.uri.fsPath);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.downloadVerifiedSmartContractEtherscan', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.downloadVerifiedSmartContractEtherscan', async () => {
         await EtherscanContractDownloader.downloadContractWithPrompts();
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.downloadRemoteVersionAndSetLocalPathSetting', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.downloadRemoteVersionAndSetLocalPathSetting', async () => {
         const root = workspaceUtil.getCurrentWorkspaceRootFolder();
         compiler.downloadRemoteVersionAndSetLocalPathSetting(vscode.ConfigurationTarget.Workspace, root.uri.fsPath);
     }));
 
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.selectGlobalRemoteSolcVersion', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.selectGlobalRemoteSolcVersion', async () => {
         compiler.selectRemoteVersion(vscode.ConfigurationTarget.Global);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('solidity.changeDefaultCompilerType', async () => {
+    context.subscriptions.push(vscode.commands.registerCommand('seismic.changeDefaultCompilerType', async () => {
         compiler.changeDefaultCompilerType(vscode.ConfigurationTarget.Workspace);
     }));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ const standAloneServerSide = false; // put this in the package json .. use this 
 // the standalone server and loade the default settings from package.json
 
 
-interface SoliditySettings {
+interface SeismicSoliditySettings {
     // option for backward compatibilities, please use "linter" option instead
     linter: boolean | string;
     enabledAsYouTypeCompilationErrorCheck: boolean;
@@ -57,12 +57,12 @@ interface SoliditySettings {
     viaIR: boolean;
 }
 
-const defaultSoliditySettings = {} as SoliditySettings;
+const defaultSeismicSoliditySettings = {} as SeismicSoliditySettings;
 Object.entries(packageJson.contributes.configuration.properties)
     .forEach(([key, value]) => {
         const keys = key.split('.');
-        if (keys.length === 2 && keys[0] === 'solidity') {
-            defaultSoliditySettings[keys[1]] = value.default;
+        if (keys.length === 3 && keys[0] === 'seismic' && keys[1] === 'solidity') {
+            defaultSeismicSoliditySettings[keys[2]] = value.default;
         }
     });
 
@@ -240,7 +240,7 @@ function validate(document: TextDocument) {
     }
 }
 
-function updateSoliditySettings(soliditySettings: SoliditySettings) {
+function updateSoliditySettings(soliditySettings: SeismicSoliditySettings) {
     enabledAsYouTypeErrorCheck = soliditySettings.enabledAsYouTypeCompilationErrorCheck;
     compileUsingLocalVersion = soliditySettings.compileUsingLocalVersion;
     compileUsingRemoteVersion = soliditySettings.compileUsingRemoteVersion;
@@ -435,7 +435,7 @@ connection.onInitialize((params): InitializeResult => {
     }
 
     if (standAloneServerSide) {
-        updateSoliditySettings(defaultSoliditySettings);
+        updateSoliditySettings(defaultSeismicSoliditySettings);
     }
     return result;
 });
@@ -477,7 +477,7 @@ connection.onDidChangeWatchedFiles(_change => {
 connection.onDidChangeConfiguration((change) => {
     if (standAloneServerSide) {
         updateSoliditySettings({
-            ...defaultSoliditySettings,
+            ...defaultSeismicSoliditySettings,
             ...(change.settings?.solidity || {}),
         });
     } else {
@@ -489,13 +489,13 @@ connection.onDidChangeConfiguration((change) => {
 
 });
 
-function linterName(settings: SoliditySettings) {
+function linterName(settings: SeismicSoliditySettings) {
     return settings.linter;
 }
 
 
 
-function linterRules(settings: SoliditySettings) {
+function linterRules(settings: SeismicSoliditySettings) {
     const _linterName = linterName(settings);
     if (_linterName === 'solium') {
         return settings.soliumRules;

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ const standAloneServerSide = false; // put this in the package json .. use this 
 // the standalone server and loade the default settings from package.json
 
 
-interface SeismicSoliditySettings {
+interface SoliditySettings {
     // option for backward compatibilities, please use "linter" option instead
     linter: boolean | string;
     enabledAsYouTypeCompilationErrorCheck: boolean;
@@ -57,12 +57,12 @@ interface SeismicSoliditySettings {
     viaIR: boolean;
 }
 
-const defaultSeismicSoliditySettings = {} as SeismicSoliditySettings;
+const defaultSoliditySettings = {} as SoliditySettings;
 Object.entries(packageJson.contributes.configuration.properties)
     .forEach(([key, value]) => {
         const keys = key.split('.');
-        if (keys.length === 2 && keys[0] === 'seismic') {
-            defaultSeismicSoliditySettings[keys[1]] = value.default;
+        if (keys.length === 2 && keys[0] === 'solidity') {
+            defaultSoliditySettings[keys[1]] = value.default;
         }
     });
 
@@ -240,7 +240,7 @@ function validate(document: TextDocument) {
     }
 }
 
-function updateSoliditySettings(soliditySettings: SeismicSoliditySettings) {
+function updateSoliditySettings(soliditySettings: SoliditySettings) {
     enabledAsYouTypeErrorCheck = soliditySettings.enabledAsYouTypeCompilationErrorCheck;
     compileUsingLocalVersion = soliditySettings.compileUsingLocalVersion;
     compileUsingRemoteVersion = soliditySettings.compileUsingRemoteVersion;
@@ -435,7 +435,7 @@ connection.onInitialize((params): InitializeResult => {
     }
 
     if (standAloneServerSide) {
-        updateSoliditySettings(defaultSeismicSoliditySettings);
+        updateSoliditySettings(defaultSoliditySettings);
     }
     return result;
 });
@@ -477,7 +477,7 @@ connection.onDidChangeWatchedFiles(_change => {
 connection.onDidChangeConfiguration((change) => {
     if (standAloneServerSide) {
         updateSoliditySettings({
-            ...defaultSeismicSoliditySettings,
+            ...defaultSoliditySettings,
             ...(change.settings?.seismic || {}),
         });
     } else {
@@ -489,13 +489,13 @@ connection.onDidChangeConfiguration((change) => {
 
 });
 
-function linterName(settings: SeismicSoliditySettings) {
+function linterName(settings: SoliditySettings) {
     return settings.linter;
 }
 
 
 
-function linterRules(settings: SeismicSoliditySettings) {
+function linterRules(settings: SoliditySettings) {
     const _linterName = linterName(settings);
     if (_linterName === 'solium') {
         return settings.soliumRules;

--- a/src/server.ts
+++ b/src/server.ts
@@ -478,11 +478,11 @@ connection.onDidChangeConfiguration((change) => {
     if (standAloneServerSide) {
         updateSoliditySettings({
             ...defaultSeismicSoliditySettings,
-            ...(change.settings?.solidity || {}),
+            ...(change.settings?.seismic || {}),
         });
     } else {
         updateSoliditySettings(
-            change.settings?.solidity,
+            change.settings?.seismic,
         );
 
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -241,8 +241,7 @@ function validate(document: TextDocument) {
 }
 
 function updateSoliditySettings(soliditySettings: SeismicSoliditySettings) {
-    console.log('ENABLED AS YOU TYPE COMPILATION ERROR CHECK: ' + soliditySettings.enabledAsYouTypeCompilationErrorCheck);
-    enabledAsYouTypeErrorCheck = true; // TODO: remove this and replace with soliditySettings.enabledAsYouTypeCompilationErrorCheck
+    enabledAsYouTypeErrorCheck = soliditySettings.enabledAsYouTypeCompilationErrorCheck;
     compileUsingLocalVersion = soliditySettings.compileUsingLocalVersion;
     compileUsingRemoteVersion = soliditySettings.compileUsingRemoteVersion;
     solhintDefaultRules = soliditySettings.solhintRules;

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,8 +61,8 @@ const defaultSeismicSoliditySettings = {} as SeismicSoliditySettings;
 Object.entries(packageJson.contributes.configuration.properties)
     .forEach(([key, value]) => {
         const keys = key.split('.');
-        if (keys.length === 3 && keys[0] === 'seismic' && keys[1] === 'solidity') {
-            defaultSeismicSoliditySettings[keys[2]] = value.default;
+        if (keys.length === 2 && keys[0] === 'seismic') {
+            defaultSeismicSoliditySettings[keys[1]] = value.default;
         }
     });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -242,7 +242,7 @@ function validate(document: TextDocument) {
 
 function updateSoliditySettings(soliditySettings: SeismicSoliditySettings) {
     console.log('ENABLED AS YOU TYPE COMPILATION ERROR CHECK: ' + soliditySettings.enabledAsYouTypeCompilationErrorCheck);
-    enabledAsYouTypeErrorCheck = soliditySettings.enabledAsYouTypeCompilationErrorCheck;
+    enabledAsYouTypeErrorCheck = true; // TODO: remove this and replace with soliditySettings.enabledAsYouTypeCompilationErrorCheck
     compileUsingLocalVersion = soliditySettings.compileUsingLocalVersion;
     compileUsingRemoteVersion = soliditySettings.compileUsingRemoteVersion;
     solhintDefaultRules = soliditySettings.solhintRules;

--- a/src/server.ts
+++ b/src/server.ts
@@ -241,6 +241,7 @@ function validate(document: TextDocument) {
 }
 
 function updateSoliditySettings(soliditySettings: SeismicSoliditySettings) {
+    console.log('ENABLED AS YOU TYPE COMPILATION ERROR CHECK: ' + soliditySettings.enabledAsYouTypeCompilationErrorCheck);
     enabledAsYouTypeErrorCheck = soliditySettings.enabledAsYouTypeCompilationErrorCheck;
     compileUsingLocalVersion = soliditySettings.compileUsingLocalVersion;
     compileUsingRemoteVersion = soliditySettings.compileUsingRemoteVersion;

--- a/src/server/linter/soliumClientFixer.ts
+++ b/src/server/linter/soliumClientFixer.ts
@@ -4,9 +4,9 @@ import * as vscode from 'vscode';
 import * as workspaceUtil from '../../client/workspaceUtil';
 
 export function lintAndfixCurrentDocument() {
-    const linterType = vscode.workspace.getConfiguration('solidity').get<string>('linter');
+    const linterType = vscode.workspace.getConfiguration('seismic').get<string>('linter');
     if (linterType === 'solium') {
-        const soliumRules = vscode.workspace.getConfiguration('solidity').get<string>('soliumRules');
+        const soliumRules = vscode.workspace.getConfiguration('seismic').get<string>('soliumRules');
         const linter = new SoliumService(
             workspaceUtil.getCurrentProjectInWorkspaceRootFsPath(), soliumRules, null);
         const editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
This PR for version `0.0.179` of the extension introduces the following:
1. Using the `seismic` namespace/key for all commands and properties instead of `solidity` in order to avoid configuration conflicts with the [original Solidity extension](https://github.com/juanfranblanco/vscode-solidity).
2. Changes downstream of (1), such as fetching the various configurations and setting commands according to the newly changed namespace.

The above changes enable clear demarcation between the two extensions for a seamless developer experience. The following screengrabs show configurations when (a) the Seismic extension is enabled and the Solidity extension is disabled and (b) the Solidity extension is enabled and the Seismic extension is disabled.

![image](https://github.com/user-attachments/assets/79c19b91-8dd3-4ed4-875c-9df399f26f2a)

![image](https://github.com/user-attachments/assets/7bd11ad7-b3af-44f2-a721-55463fa23bbb)


