### PR TITLE
fix: load config key 'seismic' instead of 'solidity' from package.json

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -61,7 +61,7 @@ const defaultSoliditySettings = {} as SoliditySettings;
 Object.entries(packageJson.contributes.configuration.properties)
     .forEach(([key, value]) => {
         const keys = key.split('.');
-        if (keys.length === 2 && keys[0] === 'solidity') {
+        if (keys.length === 2 && keys[0] === 'seismic') {
             defaultSoliditySettings[keys[1]] = value.default;
         }
     });


### PR DESCRIPTION
I attempted to set up a standalone server for my nvim, but it loaded the wrong configuration, resulting in missing language server functionalities. This PR is updating the configuration loading keys from `package.json`